### PR TITLE
Fix: Change aria-label to say EventCalendar not LinkFree (#53)

### DIFF
--- a/src/Components/Footer.js
+++ b/src/Components/Footer.js
@@ -20,7 +20,7 @@ function Footer() {
         <a
           href={"https://github.com/EddieHubCommunity/EventCalendar"}
           className="p-mr-2"
-          aria-label="LinkFree repository on GitHub"
+          aria-label="EventCalendar repository on GitHub"
         >
           <i className="pi pi-github" aria-hidden="true"></i>
         </a>


### PR DESCRIPTION
Changed the Footer GH icon's aria-label to say "EventCalendar repository on GitHub" rather than "LinkFree repository on GitHub" since the Footer was copied from the LinkFree Project

<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/EventCalendar/pull/54"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

