### PR TITLE
docs: add License to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,7 @@ Here is an example file...
 5. Run `npm run generate` to generate the calendar list data (do not change this file, it will be ignored by git)
 6. Run `npm start` to start the server
 7. Visit http://localhost:3000
+
+## 🛡️ License
+
+This project is licensed under the MIT License - see the [`LICENSE`](LICENSE) file for details.


### PR DESCRIPTION
Added the License section in [`README.md`](https://github.com/EddieHubCommunity/EventCalendar/blob/main/README.md) (Closes #46)

## Before:
![before image](https://user-images.githubusercontent.com/64855541/141940820-d1a72ec0-6c48-477c-8e29-eba294ccb778.png)

## After:
![after image](https://user-images.githubusercontent.com/64855541/141940906-7f13fc29-d408-48e6-8a03-fc5d5f279b97.png)


<a href="https://gitpod.io/#https://github.com/EddieHubCommunity/EventCalendar/pull/65"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

